### PR TITLE
Replace custom multiprocessing pipeline with sentinelhub multithreading

### DIFF
--- a/earthspy/earthspy.py
+++ b/earthspy/earthspy.py
@@ -9,7 +9,6 @@ from collections import Counter
 from datetime import datetime, timedelta
 import glob
 import json
-from multiprocessing import cpu_count, Pool, freeze_support
 import numpy as np
 import os
 from osgeo_utils import gdal_merge

--- a/earthspy/earthspy.py
+++ b/earthspy/earthspy.py
@@ -714,12 +714,11 @@ class EarthSpy:
                 for split_box in self.split_boxes
             ]
 
-        # flatten list of requests
+        # create list of requests
         self.requests_list = [item for sublist in requests_list for item in sublist]
 
-        self.download_list = [
-            item.download_list[0] for sublist in self.requests_list for item in sublist
-        ]
+        # create list of download requests
+        self.download_list = [item.download_list[0] for item in self.requests_list]
 
         return self.requests_list
 
@@ -783,7 +782,7 @@ class EarthSpy:
 
         # the actual Sentinel Hub download
         outputs = shb.SentinelHubDownloadClient(config=self.config).download(
-            self.requests_list, max_threads=self.nb_cores
+            self.download_list, max_threads=self.nb_cores
         )
 
         # store raw folders created by Sentinel Hub API

--- a/earthspy/earthspy.py
+++ b/earthspy/earthspy.py
@@ -9,6 +9,7 @@ from collections import Counter
 from datetime import datetime, timedelta
 import glob
 import json
+from multiprocessing import cpu_count
 import numpy as np
 import os
 from osgeo_utils import gdal_merge
@@ -715,6 +716,10 @@ class EarthSpy:
 
         # flatten list of requests
         self.requests_list = [item for sublist in requests_list for item in sublist]
+
+        self.download_list = [
+            item.download_list[0] for sublist in self.requests_list for item in sublist
+        ]
 
         return self.requests_list
 

--- a/earthspy/earthspy.py
+++ b/earthspy/earthspy.py
@@ -152,7 +152,7 @@ class EarthSpy:
 
         # set number of cores
         self.set_number_of_cores(nb_cores)
-        
+
         # set initial spatial and temporal coverage
         self.get_date_range(time_interval)
         self.get_bounding_box(bounding_box)
@@ -271,7 +271,7 @@ class EarthSpy:
         # set number of cores provided by user
         if self.multiprocessing and isinstance(self.nb_cores, (int, float)):
             self.nb_cores = nb_cores
-            
+
         # keep two CPUs free to prevent overload
         elif self.multiprocessing and self.nb_cores is None:
             self.nb_cores = cpu_count() - 2
@@ -835,20 +835,14 @@ class EarthSpy:
             start_time = time.time()
             start_local_time = time.ctime(start_time)
 
-        # store raw folders created by Sentinel Hub API
-        raw_filenames = []
+        outputs = shb.SentinelHubDownloadClient(config=self.config).download(
+            self.requests_list, max_threads=self.nb_cores
+        )
 
-        if self.multiprocessing:
-    
-            outputs = shb.SentinelHubDownloadClient(config=self.config).download(self.requests_list, max_threads=self.nb_cores)
-                    # get raw files names for renaming
-                    if shb_requests is not None:
-                        raw_filenames.append(
-                            [
-                                r.get_filename_list()[0].split(os.sep)[0]
-                                for r in shb_requests
-                            ]
-                        )
+        # store raw folders created by Sentinel Hub API
+        self.raw_filenames = [
+            r.get_filename_list()[0].split(os.sep)[0] for r in self.requests_list
+        ]
 
         # change raw ambiguous file names
         self.rename_output_files()

--- a/earthspy/earthspy.py
+++ b/earthspy/earthspy.py
@@ -781,7 +781,7 @@ class EarthSpy:
             start_local_time = time.ctime(start_time)
 
         # the actual Sentinel Hub download
-        outputs = shb.SentinelHubDownloadClient(config=self.config).download(
+        self.outputs = shb.SentinelHubDownloadClient(config=self.config).download(
             self.download_list, max_threads=self.nb_cores
         )
 
@@ -806,7 +806,7 @@ class EarthSpy:
             print("--- Start time: %s ---" % start_local_time)
             print("--- End time: %s ---" % end_local_time)
 
-        return None
+        return self.outputs
 
     def rename_output_files(self) -> None:
         """Reorganise the default folder structure and file naming of Sentinel Hub


### PR DESCRIPTION
I initially implemented a multiprocessing pipeline with a multiprocessing strategy depending on the number of days and split boxes to process (if only a couple of days to process but many split boxes, it makes more sense to distribute jobs over the different split boxes than over days). The Sentinel Hub services already offer multithreading capabilities, so let's use this instead to make the tool more simple and probably more stable!

On a simple test over Ilulissat in Greenland downloading 2017-05-01 to 2017-09-01 of Sentinel-1 EW data no significant improvement in download efficiency have been observed.