### PR TITLE
get evaluation script from local JS file

### DIFF
--- a/earthspy/earthspy.py
+++ b/earthspy/earthspy.py
@@ -662,6 +662,24 @@ class EarthSpy:
 
         return self.evaluation_script
 
+    def get_evaluation_script_from_file(
+        self, evaluation_script: Union[None, str]
+    ) -> str:
+        """Get evaluation script from JavaScript file stored locally.
+
+        :param evaluation_script: full local path to JavaScript file.
+        :type evaluation_script: Union[None, str]
+
+        :return: Custom script.
+        :rtype: str
+        """
+
+        # read file and store content
+        with open(evaluation_script, "r") as f:
+            self.evaluation_script = f.read()
+
+        return self.evaluation_script
+
     def set_split_boxes_ids(self) -> dict:
         """Set split boxes ids as simple integers to be accessed anytime in random order
         (mostly for multithreading).
@@ -702,6 +720,13 @@ class EarthSpy:
         elif validators.url(evaluation_script):
 
             self.evaluation_script = self.get_evaluation_script_from_link(
+                evaluation_script
+            )
+
+        # if path to a JavaScript file, read file
+        elif ".js" in evaluation_script:
+
+            self.evaluation_script = self.get_evaluation_script_from_file(
                 evaluation_script
             )
 


### PR DESCRIPTION
At present, possible inputs for evaluation scripts are strings and URLs. Now, it is possible to directly pass the path to a local JavaScript file that will be read and stored as a string.