### PR TITLE
Rename conda environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: earthspy-devdev
+name: earthspy
 channels:
   - conda-forge/label/cf202003
   - https://conda.software.inl.gov/public


### PR DESCRIPTION
Conda environment hasn't been changed since initial development phase (`earthspy-devdev`), modify for `earthspy`. 