### PR TITLE
Add point of interest and buffer distance as a bounding box option

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,4 @@ dependencies:
   - rasterio
   - sentinelhub >= 3.4
   - pip
+  - pyproj


### PR DESCRIPTION
Users expressed the wish to download data at a given point and its surroundings, which then requires the user to compute the coordinates at a given distance around the point of interest to create a 4-point bounding box. Here, an option to set bounding box as a point of interest and distance around point has been added.